### PR TITLE
Detect max rate via p99 latency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,4 @@ jobs:
           context: .
           file: docker/Dockerfile.build
           push: true
-          tags: streamnative/benchmark:${{ github.ref }}
+          tags: streamnative/benchmark:${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - master
-      - base
+      - base_image
   push:
     branches:
       - master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - base
   push:
     branches:
       - master
@@ -33,4 +34,4 @@ jobs:
           context: .
           file: docker/Dockerfile.build
           push: true
-          tags: streamnative/benchmark:base
+          tags: streamnative/benchmark:${{ github.ref }}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -193,6 +193,7 @@ public class WorkloadGenerator implements AutoCloseable {
      */
     private void findMaximumSustainableRate(double currentRate) throws IOException {
         CountersStats stats = worker.getCountersStats();
+        PeriodStats periodStats = worker.getPeriodStats();
 
         int controlPeriodMillis = 3000;
         long lastControlTimestamp = System.nanoTime();
@@ -209,6 +210,9 @@ public class WorkloadGenerator implements AutoCloseable {
 
             // Consider multiple copies when using multiple subscriptions
             stats = worker.getCountersStats();
+            periodStats = worker.getPeriodStats();
+
+
             long currentTime = System.nanoTime();
             long periodNanos = currentTime - lastControlTimestamp;
 
@@ -216,7 +220,7 @@ public class WorkloadGenerator implements AutoCloseable {
 
             currentRate =
                     rateController.nextRate(
-                            currentRate, periodNanos, stats.messagesSent, stats.messagesReceived);
+                            currentRate, periodNanos, stats.messagesSent, stats.messagesReceived, periodStats);
             worker.adjustPublishRate(currentRate);
         }
     }
@@ -373,7 +377,9 @@ public class WorkloadGenerator implements AutoCloseable {
                                     - stats.totalMessagesReceived);
 
             log.info(
-                    "Pub rate {} msg/s / {} MB/s | Pub err {} err/s | Cons rate {} msg/s / {} MB/s | Backlog: {} K | Pub Latency (ms) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {} | Pub Delay Latency (us) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {}",
+                    "Pub rate {} msg/s / {} MB/s | Pub err {} err/s | Cons rate {} msg/s / {} MB/s | Backlog: {} K | "
+                            + "Pub Latency (ms) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {} | Pub Delay Latency"
+                            + " (us) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {}",
                     rateFormat.format(publishRate),
                     throughputFormat.format(publishThroughput),
                     rateFormat.format(errorRate),
@@ -433,7 +439,9 @@ public class WorkloadGenerator implements AutoCloseable {
             if (now >= testEndTime && !needToWaitForBacklogDraining) {
                 CumulativeLatencies agg = worker.getCumulativeLatencies();
                 log.info(
-                        "----- Aggregated Pub Latency (ms) avg: {} - 50%: {} - 95%: {} - 99%: {} - 99.9%: {} - 99.99%: {} - Max: {} | Pub Delay (us)  avg: {} - 50%: {} - 95%: {} - 99%: {} - 99.9%: {} - 99.99%: {} - Max: {}",
+                        "----- Aggregated Pub Latency (ms) avg: {} - 50%: {} - 95%: {} - 99%: {} - 99.9%: {} - 99"
+                                + ".99%: {} - Max: {} | Pub Delay (us)  avg: {} - 50%: {} - 95%: {} - 99%: {} - 99"
+                                + ".9%: {} - 99.99%: {} - Max: {}",
                         dec.format(agg.publishLatency.getMean() / 1000.0),
                         dec.format(agg.publishLatency.getValueAtPercentile(50) / 1000.0),
                         dec.format(agg.publishLatency.getValueAtPercentile(95) / 1000.0),
@@ -527,11 +535,11 @@ public class WorkloadGenerator implements AutoCloseable {
     private static final DecimalFormat throughputFormat = new PaddingDecimalFormat("0.0", 4);
     private static final DecimalFormat dec = new PaddingDecimalFormat("0.0", 4);
 
-    private static double microsToMillis(double timeInMicros) {
+    public static double microsToMillis(double timeInMicros) {
         return timeInMicros / 1000.0;
     }
 
-    private static double microsToMillis(long timeInMicros) {
+    public static double microsToMillis(long timeInMicros) {
         return timeInMicros / 1000.0;
     }
 

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/RateControllerTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/RateControllerTest.java
@@ -28,12 +28,12 @@ class RateControllerTest {
         assertThat(rateController.getRampingFactor()).isEqualTo(1);
 
         // no backlog
-        rate = rateController.nextRate(rate, periodNanos, 10_000, 10_000);
+        rate = rateController.nextRate(rate, periodNanos, 10_000, 10_000, null);
         assertThat(rate).isEqualTo(20_000);
         assertThat(rateController.getRampingFactor()).isEqualTo(1);
 
         // receive backlog
-        rate = rateController.nextRate(rate, periodNanos, 20_000, 15_000);
+        rate = rateController.nextRate(rate, periodNanos, 20_000, 15_000, null);
         assertThat(rate).isEqualTo(5_000);
         assertThat(rateController.getRampingFactor()).isEqualTo(0.5);
     }
@@ -43,12 +43,12 @@ class RateControllerTest {
         assertThat(rateController.getRampingFactor()).isEqualTo(1);
 
         // no backlog
-        rate = rateController.nextRate(rate, periodNanos, 10_000, 10_000);
+        rate = rateController.nextRate(rate, periodNanos, 10_000, 10_000, null);
         assertThat(rate).isEqualTo(20_000);
         assertThat(rateController.getRampingFactor()).isEqualTo(1);
 
         // publish backlog
-        rate = rateController.nextRate(rate, periodNanos, 15_000, 20_000);
+        rate = rateController.nextRate(rate, periodNanos, 15_000, 20_000, null);
         assertThat(rate).isEqualTo(5_000);
         assertThat(rateController.getRampingFactor()).isEqualTo(0.5);
     }
@@ -58,12 +58,12 @@ class RateControllerTest {
         assertThat(rateController.getRampingFactor()).isEqualTo(1);
 
         // receive backlog
-        rate = rateController.nextRate(rate, periodNanos, 10_000, 5_000);
+        rate = rateController.nextRate(rate, periodNanos, 10_000, 5_000, null);
         assertThat(rate).isEqualTo(5_000);
         assertThat(rateController.getRampingFactor()).isEqualTo(0.5);
 
         // no backlog
-        rate = rateController.nextRate(rate, periodNanos, 20_000, 20_000);
+        rate = rateController.nextRate(rate, periodNanos, 20_000, 20_000, null);
         assertThat(rate).isEqualTo(10_000);
         assertThat(rateController.getRampingFactor()).isEqualTo(1);
     }


### PR DESCRIPTION
- If `p99PublishLatency` and `p99EndToEndLatency` are set to 0 or not set, the max rate will be decided by backlog.
- If actual latency is larger than target latency, it will decrease the publish rate to `rate * (target latency / actual latency)` and `rampingFactor`